### PR TITLE
Bump linkifyjs from 4.3.1 to 4.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10089,9 +10089,9 @@ __metadata:
   linkType: hard
 
 "linkifyjs@npm:^4.2.0":
-  version: 4.3.1
-  resolution: "linkifyjs@npm:4.3.1"
-  checksum: fcd7d36ce1b03adb19dcc84b3b375f0b9d6e88d8885461bc69e5d5cbf1cd666cd740e175f015ac5ce600154a4f2bc68f4aed3920b1254aa4c6e9b42f49b3de79
+  version: 4.3.2
+  resolution: "linkifyjs@npm:4.3.2"
+  checksum: 1a85e6b368304a4417567fe5e38651681e3e82465590836942d1b4f3c834cc35532898eb1e2479f6337d9144b297d418eb708b6be8ed0b3dc3954a3588e07971
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves a dependabot security alert. (only affects the demo)

See https://github.com/marmelab/react-admin/pull/10868 for changelog details.